### PR TITLE
have console menu handle nested options

### DIFF
--- a/src/bl3_mod_menu/options_callbacks.py
+++ b/src/bl3_mod_menu/options_callbacks.py
@@ -65,8 +65,6 @@ def unimplemented_option_clicked(
     match option:
         case NestedOption():
             open_nested_options_menu(option)
-            if option.on_press is not None:
-                option.on_press(option)
         case ButtonOption():
             if option.on_press is not None:
                 option.on_press(option)

--- a/src/bl3_mod_menu/options_setup.py
+++ b/src/bl3_mod_menu/options_setup.py
@@ -95,7 +95,7 @@ def draw_options(
             option_stack[-1].drawn_options.append(option)
 
         match option:
-            case ButtonOption():
+            case ButtonOption() | NestedOption():
                 add_button(self, option.display_name, option.description_title, option.description)
 
             case BoolOption():

--- a/src/console_mod_menu/option_formatting.py
+++ b/src/console_mod_menu/option_formatting.py
@@ -2,6 +2,9 @@ from typing import TypeVar, overload
 
 from mods_base import JSON, BaseOption, BoolOption, KeybindOption, ValueOption
 
+from .draw import draw
+from .screens import draw_stack_header
+
 J = TypeVar("J", bound=JSON)
 
 
@@ -39,3 +42,30 @@ def get_option_value_str(option: BaseOption) -> str | None:
             return str(option.value)  # type: ignore
         case _:
             return None
+
+
+def draw_option_header(option: BaseOption) -> None:
+    """
+    Draws the header for a particular option.
+
+    Args:
+        option: The option to draw the header for.
+    """
+    draw_stack_header()
+
+    title = option.display_name
+    value_str = get_option_value_str(option)
+    if value_str is not None:
+        title += f" ({value_str})"
+    draw(title)
+
+    if option.description_title != option.display_name:
+        draw(option.description_title)
+
+    if len(option.description) > 0:
+        draw("=" * 32)
+        # Respect newlines - passing everything at once would let them get wrapped arbitrarily
+        for line in option.description.splitlines():
+            draw(line)
+
+    draw("")

--- a/src/console_mod_menu/screens/option.py
+++ b/src/console_mod_menu/screens/option.py
@@ -17,14 +17,9 @@ from mods_base import (
 )
 
 from console_mod_menu.draw import draw
-from console_mod_menu.option_formatting import get_option_value_str
+from console_mod_menu.option_formatting import draw_option_header
 
-from . import (
-    AbstractScreen,
-    draw_stack_header,
-    draw_standard_commands,
-    handle_standard_command_input,
-)
+from . import AbstractScreen, draw_standard_commands, handle_standard_command_input
 
 T = TypeVar("T", bound=BaseOption)
 J = TypeVar("J", bound=JSON)
@@ -40,25 +35,7 @@ class OptionScreen(AbstractScreen, Generic[T, J]):
         self.name = self.option.display_name
 
     def draw(self) -> None:  # noqa: D102
-        draw_stack_header()
-
-        title = self.option.display_name
-        value_str = get_option_value_str(self.option)
-        if value_str is not None:
-            title += f" ({value_str})"
-        draw(title)
-
-        if self.option.description_title != self.option.display_name:
-            draw(self.option.description_title)
-
-        if len(self.option.description) > 0:
-            draw("=" * 32)
-            # Respect newlines - passing everything at once would let them get wrapped arbitrarily
-            for line in self.option.description.splitlines():
-                draw(line)
-
-        draw("")
-
+        draw_option_header(self.option)
         self.draw_option()
 
     @abstractmethod

--- a/src/mods_base/options.py
+++ b/src/mods_base/options.py
@@ -374,7 +374,7 @@ class GroupedOption(BaseOption):
 
 
 @dataclass
-class NestedOption(ButtonOption):
+class NestedOption(BaseOption):
     """
     A nested group of options, which appear in a new menu.
 
@@ -390,8 +390,6 @@ class NestedOption(ButtonOption):
         description: A short description about the option.
         description_title: The title of the description. Defaults to copying the display name.
         is_hidden: If true, the option will not be shown in the options menu.
-        on_press: If not None, the callback to run when the button is pressed (and the nested menu
-                  opened). Passed a reference to the option object.
     Extra Attributes:
         mod: The mod this option stores it's settings in, or None if not (yet) associated with one.
     """


### PR DESCRIPTION
also remove button from the nested option inheritence chain - didn't make much sense, and you needed to special case it everywhere anyway

this is technically a breaking change, but it only matters for mod menus