### PR TITLE
mods base improvements in preparation of bl2 manager

### DIFF
--- a/src/bl3_mod_menu/outer_menu.py
+++ b/src/bl3_mod_menu/outer_menu.py
@@ -109,6 +109,7 @@ def draw_mods_list(main_menu: UObject) -> None:
         if not mod.is_enabled and not RE_FONT_TAG.match(mod.name):
             formatted_name = f"<font color='{DISABLED_GRAY}'>{mod.name}</font>"
 
+        formatted_name += f" <font size='20'>{mod.get_status()}</font>"
         add_menu_item(main_menu, formatted_name, "OnInviteListClearClicked", False, -1)
 
     # If we have too many mods, they'll end up scrolling behind the news box

--- a/src/console_mod_menu/screens/home.py
+++ b/src/console_mod_menu/screens/home.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from mods_base import Mod, get_ordered_mod_list
+from mods_base import Mod, get_ordered_mod_list, html_to_plain_text
 
 from console_mod_menu.draw import draw
 
@@ -26,7 +26,16 @@ class HomeScreen(AbstractScreen):
 
         self.drawn_mod_list = get_ordered_mod_list()
         for idx, mod in enumerate(self.drawn_mod_list):
-            draw(f"[{idx + 1}] {mod.name}" + (" (Disabled)" if not mod.is_enabled else ""))
+            status = html_to_plain_text(mod.get_status()).strip()
+            suffix = f" ({status})"
+
+            # Filter out the standard enabled statuses, for more variation in the list - it's harder
+            # to tell what's enabled or not when every single entry has a suffix
+            # If there's a custom status, we'll still show that
+            if mod.is_enabled and status in ("Enabled", "Loaded"):
+                suffix = ""
+
+            draw(f"[{idx + 1}] {mod.name}{suffix}")
 
         draw_standard_commands()
 

--- a/src/console_mod_menu/screens/mod.py
+++ b/src/console_mod_menu/screens/mod.py
@@ -127,6 +127,28 @@ class ModScreen(OptionListScreen):
     def draw(self) -> None:  # noqa: D102
         draw_stack_header()
 
+        header = ""
+        if self.mod.author:
+            header += f"By {self.mod.author}"
+        if self.mod.author and self.mod.version:
+            header += "  -  "
+        if self.mod.version:
+            header += self.mod.version
+        draw(header)
+
+        draw(self.mod.get_status())
+        draw("")
+
+        if self.mod.description:
+            draw(self.mod.description)
+            draw("")
+
+        if not self.mod.enabling_locked:
+            if self.mod.is_enabled:
+                draw("[D] Disable")
+            else:
+                draw("[E] Enable")
+
         self.drawn_options = []
         self.draw_options_list(self.mod.iter_display_options(), [])
 
@@ -135,6 +157,14 @@ class ModScreen(OptionListScreen):
     def handle_input(self, line: str) -> bool:  # noqa: D102
         if handle_standard_command_input(line):
             return True
+
+        if not self.mod.enabling_locked:
+            if self.mod.is_enabled and line.lower() == "d":
+                self.mod.disable()
+                return True
+            if not self.mod.is_enabled and line.lower() == "e":
+                self.mod.enable()
+                return True
 
         return self.handle_option_input(line)
 

--- a/src/mods_base/mod.py
+++ b/src/mods_base/mod.py
@@ -272,6 +272,14 @@ class Mod:
                 [KeybindOption.from_keybind(bind) for bind in self.keybinds],
             )
 
+    def get_status(self) -> str:
+        """Gets the current status of this mod. Should be a single line."""
+        if Game.get_current() not in self.supported_games:
+            return "<font color='#ffff00'>Incompatible</font>"
+        if self.is_enabled:
+            return "<font color='#00ff00'>Enabled</font>"
+        return "<font color='#ff0000'>Disabled</font>"
+
 
 @dataclass
 class Library(Mod):
@@ -292,3 +300,9 @@ class Library(Mod):
             self.enable()
         # And then lock
         self.enabling_locked = True
+
+    def get_status(self) -> str:
+        """Gets the current status of this mod."""
+        if Game.get_current() not in self.supported_games:
+            return "<font color='#ffff00'>Incompatible</font>"
+        return "<font color='#00ff00'>Loaded</font>"

--- a/src/mods_base/mod_list.py
+++ b/src/mods_base/mod_list.py
@@ -11,11 +11,18 @@ from . import MODS_DIR, __version__
 from .command import AbstractCommand
 from .hook import HookProtocol
 from .keybinds import KeybindType
-from .mod import Library, Mod, ModType
+from .mod import Game, Library, Mod, ModType
 from .options import BaseOption, ButtonOption
 from .settings import SETTINGS_DIR
 
-MOD_DB_URL = "https://bl-sdk.github.io/oak-mod-db/"
+MOD_DB_URL: str
+match Game.get_tree():
+    case Game.Willow2:
+        MOD_DB_URL = "https://bl-sdk.github.io/"  # pyright: ignore[reportConstantRedefinition]
+    case Game.Oak:
+        MOD_DB_URL = (  # pyright: ignore[reportConstantRedefinition]
+            "https://bl-sdk.github.io/oak-mod-db/"
+        )
 
 
 @dataclass

--- a/src/mods_base/options.py
+++ b/src/mods_base/options.py
@@ -40,7 +40,7 @@ class BaseOption(ABC):
     description_title: str = None  # type: ignore
     is_hidden: bool = False
 
-    mod: "Mod | None" = field(default=None, init=False)
+    mod: "Mod | None" = field(default=None, init=False, repr=False)
 
     @abstractmethod
     def __init__(self) -> None:


### PR DESCRIPTION
- handle current "tree" (willow vs oak) in mods base
- remove header from iter display options, in favor of each mod menu using `description` add `enabling_locked` directly
- add `get_status`
- misc fixes