### PR TITLE
update outdated download artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
 
     - name: Create new release tag
       uses: rickstaa/action-create-tag@v1


### PR DESCRIPTION
since we upload with v4, download v3 couldn't find anything