### PR TITLE
Move `mods_base.raw_keybinds` to `keybinds.raw_keybinds`, init script improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,7 +364,6 @@ jobs:
     - name: Run pyright
       uses: jakebailey/pyright-action@v2
       with:
-        pylance-version: latest-release
         working-directory: "./src/"
 
   ruff:

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,52 @@
 # Changelog
 
-## Upcoming
+## v1.3 (Upcoming)
+
+### General
+- Added a warning for when Proton fails to propagate environment variables, which mods or the mod
+  manager may have been expecting.
+  
+  An example consequence of this is that the base mod may end up as version "Unknown Version".
+
+  [f420d77b](https://github.com/bl-sdk/oak-mod-manager/commit/f420d77b)
+
+### General - Developer
+- When developing third party native modules, you can now include this repo as a submodule to
+  automatically keep the Python version in sync. There was a bit of build system restructuring to
+  allow our `CMakeLists.txt` to define this.
+
+  [6f9a8717](https://github.com/bl-sdk/oak-mod-manager/commit/6f9a8717)
+
+- Changed the `OAK_MOD_MANAGER_EXTRA_FOLDERS` env var to read from `MOD_MANAGER_EXTRA_FOLDERS`
+  instead, for consistency.
+  
+  [f420d77b](https://github.com/bl-sdk/oak-mod-manager/commit/f420d77b)
+
+- Python warnings are now hooked up to the logging system.
+  
+  [f420d77b](https://github.com/bl-sdk/oak-mod-manager/commit/f420d77b)
 
 ### BL3 Mod Menu v1.2
 
 - Updated type hinting to use 3.12 syntax.
 
-  [dfb72a92](https://github.com/bl-sdk/oak-mod-manager/commit/dfb72a92)
+  [dfb72a92](https://github.com/bl-sdk/oak-mod-manager/commit/dfb72a92),
+  [95cc37eb](https://github.com/bl-sdk/oak-mod-manager/commit/95cc37eb)
+
+### Console Mod Menu v1.2
+
+- Updated type hinting to use 3.12 syntax.
+
+  [95cc37eb](https://github.com/bl-sdk/oak-mod-manager/commit/95cc37eb)
+
+- Changed strict keybind and ui utils dependencies to be soft dependencies. This is of no
+  consequence to this project, but it makes the mod menu more game-agnostic for other ones.
+  
+  These dependencies were only used for the "Rebind using key press" screen, this functionality will
+  now gracefully degrade based on what's available. 
+
+  [9ab26173](https://github.com/bl-sdk/oak-mod-manager/commit/9ab26173),
+  [216a739d](https://github.com/bl-sdk/oak-mod-manager/commit/216a739d)
 
 ### Keybinds v2.2
 
@@ -14,11 +54,20 @@
 
   [dfb72a92](https://github.com/bl-sdk/oak-mod-manager/commit/dfb72a92)
 
+- Moved `raw_keybinds` out of mods base, into keybinds.
+
+  [216a739d](https://github.com/bl-sdk/oak-mod-manager/commit/216a739d)
+
 ### Mods Base v1.3
 
 - Updated type hinting to use 3.12 syntax.
 
   [dfb72a92](https://github.com/bl-sdk/oak-mod-manager/commit/dfb72a92)
+  [95cc37eb](https://github.com/bl-sdk/oak-mod-manager/commit/95cc37eb)
+
+- Moved `raw_keybinds` out of mods base, into keybinds.
+
+  [216a739d](https://github.com/bl-sdk/oak-mod-manager/commit/216a739d)
 
 ## v1.2
 

--- a/manager_pyproject.toml
+++ b/manager_pyproject.toml
@@ -5,7 +5,7 @@
 
 [project]
 name = "oak_mod_manager"
-version = "1.2"
+version = "1.3"
 authors = [{ name = "bl-sdk" }]
 
 [tool.sdkmod]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -17,10 +17,16 @@ import json
 import os
 import sys
 import traceback
+import warnings
 import zipfile
 from collections.abc import Collection
+from functools import wraps
 from pathlib import Path
+from typing import TextIO
 
+# Note we try to import as few third party modules as possible before the console is ready, in case
+# any of them cause errors we'd like to have logged
+# Trusting that we can keep all the above standard library modules without issue
 import unrealsdk
 from unrealsdk import logging
 
@@ -31,7 +37,7 @@ FULL_TRACEBACKS: bool = False
 WAIT_FOR_CLIENT: bool = False
 
 # A json list of paths to also to import mods from - you can add your repo to keep it separated
-EXTRA_FOLDERS_ENV_VAR: str = "OAK_MOD_MANAGER_EXTRA_FOLDERS"
+EXTRA_FOLDERS_ENV_VAR: str = "MOD_MANAGER_EXTRA_FOLDERS"
 
 
 def init_debugpy() -> None:
@@ -236,14 +242,40 @@ def import_mods(mods_to_import: Collection[str]) -> None:
             logging.error("".join(traceback.format_list(tb)))
 
 
-def proton_null_exception_check() -> None:
-    """
-    Tries to detect and warn if we're running under a version of Proton which has the exception bug.
+def hookup_warnings() -> None:
+    """Hooks up the Python warnings system to the dev warning log type."""
 
-    For context, usually pybind detects exceptions using a catch all, which eventually calls through
-    to `std::current_exception` to get the exact exception, and then runs a bunch of translators on
-    it to convert it to a Python exception. When running under a bad Proton version, this call
-    fails, and returns an empty exception pointer, so pybind is unable to translate it.
+    original_show_warning = warnings.showwarning
+    dev_warn_logger = logging.Logger(logging.Level.DEV_WARNING)
+
+    @wraps(warnings.showwarning)
+    def showwarning(
+        message: Warning | str,
+        category: type[Warning],
+        filename: str,
+        lineno: int,
+        file: TextIO | None = None,
+        line: str | None = None,
+    ) -> None:
+        if file is None:
+            # Typeshed has this as a TextIO, but the implementation only actually uses `.write`
+            file = dev_warn_logger  # type: ignore
+        original_show_warning(message, category, filename, lineno, file, line)
+
+    warnings.showwarning = showwarning
+    warnings.resetwarnings()  # Reset filters, show all warnings
+
+
+def check_proton_bugs() -> None:
+    """Tries to detect and warn about various known proton issues."""
+
+    """
+    The exception bug
+    -----------------
+    Usually pybind detects exceptions using a catch all, which eventually calls through to
+    `std::current_exception` to get the exact exception, and then runs a bunch of translators on it
+    to convert it to a Python exception. When running under a bad Proton version, this call fails,
+    and returns an empty exception pointer, so pybind is unable to translate it.
 
     This means Python throws a:
     ```
@@ -251,14 +283,13 @@ def proton_null_exception_check() -> None:
     ```
     This is primarily a problem for `StopIteration`.
     """  # noqa: E501
-
     cls = unrealsdk.find_class("Object")
     try:
         # Cause an attribute error
         _ = cls._check_for_proton_null_exception_bug
     except AttributeError:
         # Working properly
-        return
+        pass
     except SystemError:
         # Have the bug
         logging.error(
@@ -268,10 +299,30 @@ def proton_null_exception_check() -> None:
         logging.error(
             "\n"
             "Some particular Proton versions cause this, try switch to another one.\n"
-            "Alternatively, the nightly release has builds from other compilers, which may also"
-            " prevent it.\n"
+            "Alternatively, the nightly release has builds from other compilers, which may\n"
+            "also prevent it.\n"
             "\n"
             "Will attempt to import mods, but they'll likely break with a similar error.\n"
+            "===============================================================================",
+        )
+
+    """
+    Env vars not propagating
+    ------------------------
+    We set various env vars in `unrealsdk.env`, which unrealsdk sets via `SetEnvironmentVariableA`.
+    On some proton versions this does not get propagated through to Python - despite clearly having
+    worked for pyunrealsdk, if we're able to run this script. Some of these are used by Python, and
+    may cause issues if we cannot find them.
+    """
+    if "PYUNREALSDK_INIT_SCRIPT" not in os.environ:
+        logging.error(
+            "===============================================================================\n"
+            "Some environment variables don't seem to have propagated into Python. This may\n"
+            "cause issues in parts of the mod manager or individual mods which expect them.\n"
+            "\n"
+            "Some particular Proton versions cause this, try switch to another one.\n"
+            "Alternatively, the nightly release has builds from other compilers, which may\n"
+            "also prevent it.\n"
             "===============================================================================",
         )
 
@@ -288,13 +339,14 @@ init_debugpy()
 while not logging.is_console_ready():
     pass
 
-# Now that the console's ready, show errors for any non-existent mod folders
+# Now that the console's ready, hook up the warnings system, and show some other warnings users may
+# be interested in
+hookup_warnings()
+
+check_proton_bugs()
 for folder in mod_folders:
     if not folder.exists() or not folder.is_dir():
         logging.dev_warning(f"Extra mod folder does not exist: {folder}")
-
-# And check for the proton null exception bug, if present we also want to print
-proton_null_exception_check()
 
 mods_to_import = find_mods_to_import(mod_folders)
 

--- a/src/bl3_mod_menu/keybinds.py
+++ b/src/bl3_mod_menu/keybinds.py
@@ -1,7 +1,8 @@
 from enum import StrEnum
 
 import unrealsdk
-from mods_base import BoolOption, DropdownOption, EInputEvent, KeybindOption, get_pc, raw_keybinds
+from keybinds import raw_keybinds
+from mods_base import BoolOption, DropdownOption, EInputEvent, KeybindOption, get_pc
 from unrealsdk.unreal import UObject
 
 from .dialog_box import DialogBox

--- a/src/console_mod_menu/__init__.py
+++ b/src/console_mod_menu/__init__.py
@@ -11,7 +11,7 @@ __all__: tuple[str, ...] = (
     "__version_info__",
 )
 
-__version_info__: tuple[int, int] = (1, 1)
+__version_info__: tuple[int, int] = (1, 2)
 __version__: str = f"{__version_info__[0]}.{__version_info__[1]}"
 __author__: str = "bl-sdk"
 

--- a/src/keybinds/__init__.py
+++ b/src/keybinds/__init__.py
@@ -4,13 +4,6 @@ from typing import cast
 from mods_base import KeybindType
 from mods_base.keybinds import KeybindCallback_Event, KeybindCallback_NoArgs
 from mods_base.mod_list import base_mod
-from mods_base.raw_keybinds import (
-    RawKeybind,
-    RawKeybindCallback_EventOnly,
-    RawKeybindCallback_KeyAndEvent,
-    RawKeybindCallback_KeyOnly,
-    RawKeybindCallback_NoArgs,
-)
 
 from .keybinds import deregister_keybind, register_keybind
 
@@ -81,59 +74,6 @@ def rebind_keybind(self: KeybindType, new_key: str | None) -> None:
 
 
 KeybindType._rebind = rebind_keybind  # pyright: ignore[reportPrivateUsage]
-
-
-@wraps(RawKeybind.enable)
-def enable_raw_keybind(self: RawKeybind) -> None:
-    # Even more redundancy for type checking
-    # Can't use a match statement since an earlier `case None:` doesn't remove None from later cases
-    if self.key is None:
-        if self.event is None:
-            handle = register_keybind(
-                self.key,
-                self.event,
-                False,
-                cast(RawKeybindCallback_KeyAndEvent, self.callback),
-            )
-        else:
-            handle = register_keybind(
-                self.key,
-                self.event,
-                False,
-                cast(RawKeybindCallback_KeyOnly, self.callback),
-            )
-    elif self.event is None:
-        handle = register_keybind(
-            self.key,
-            self.event,
-            False,
-            cast(RawKeybindCallback_EventOnly, self.callback),
-        )
-    else:
-        handle = register_keybind(
-            self.key,
-            self.event,
-            False,
-            cast(RawKeybindCallback_NoArgs, self.callback),
-        )
-
-    self._kb_handle = handle  # type: ignore
-
-
-RawKeybind.enable = enable_raw_keybind
-
-
-@wraps(RawKeybind.disable)
-def disable_raw_keybind(self: RawKeybind) -> None:
-    handle = getattr(self, "_kb_handle", None)
-    if handle is None:
-        return
-
-    deregister_keybind(handle)
-    self._kb_handle = None  # type: ignore
-
-
-RawKeybind.disable = disable_raw_keybind
 
 
 base_mod.components.append(base_mod.ComponentInfo("Keybinds", __version__))

--- a/src/mods_base/__init__.py
+++ b/src/mods_base/__init__.py
@@ -21,7 +21,6 @@ if True:
     )
     del _mod_dir
 
-from . import raw_keybinds
 from .command import (
     AbstractCommand,
     ArgParseCommand,
@@ -88,7 +87,6 @@ __all__: tuple[str, ...] = (
     "ModType",
     "NestedOption",
     "open_in_mod_dir",
-    "raw_keybinds",
     "register_mod",
     "remove_next_console_line_capture",
     "SETTINGS_DIR",

--- a/src/mods_base/keybinds.py
+++ b/src/mods_base/keybinds.py
@@ -35,8 +35,10 @@ class KeybindType:
     """
     Represents a single keybind.
 
-    The input callback takes no args, and may return the Block sentinel to prevent passing the input
-    back into the game. Standard blocking logic applies when multiple keybinds use the same key.
+    The input callback takes no args, and may return the Block sentinel to try prevent passing the
+    input back into the game. Note that this depends on the keybinds implementation, implementations
+    may not necessarily implement blocking. If it is implemented, standard blocking logic applies
+    when multiple keybinds use the same key.
 
     Args:
         identifier: The keybind's identifier.


### PR DESCRIPTION
This comes from working on the willow mod manager. The interface has proven difficult to implement in willow, and it doesn't actually see much use for it. Willow has a lot more access to the UI, you can directly hook inputs on the specific GUI you're interested in, so there's little point in using `raw_keybinds`. It's still handy in oak, so let's make it oak-specific.

The only external mod using raw keybinds is my Hunt Tracker, which I've already put up an update for in https://github.com/apple1417/oak-sdk-mods/pull/5. This means we don't really need to leave compatibility. 

Also contains some extra warnings I found for the init script.