### PR TITLE
add release names to changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.5
+## v1.5: Time Skip
 
 ### General
 - Upgraded to Python 3.13.
@@ -49,7 +49,7 @@
 > - Fixed missing all `CallFunction` based hooks in TPS - notably including the say bypass.
 > - Added the offline mode say crash fix for BL2+TPS as a base sdk hook.
 
-## v1.4
+## v1.4: White Elephant
 
 Also see the unrealsdk v1.3.0 changelog [here](https://github.com/bl-sdk/unrealsdk/blob/master/changelog.md#v130)
 and the pyunrealsdk v1.3.0 changelog [here](https://github.com/bl-sdk/pyunrealsdk/blob/master/changelog.md#v130).
@@ -107,7 +107,7 @@ and the pyunrealsdk v1.3.0 changelog [here](https://github.com/bl-sdk/pyunrealsd
 
   [51d3c872](https://github.com/bl-sdk/oak-mod-manager/commit/51d3c872)
 
-## v1.3
+## v1.3: Lethal Catch
 
 Also see the unrealsdk v1.2.0 changelog [here](https://github.com/bl-sdk/unrealsdk/blob/master/changelog.md#v120)
 and the pyunrealsdk v1.2.0 changelog [here](https://github.com/bl-sdk/pyunrealsdk/blob/master/changelog.md#v120).
@@ -193,7 +193,7 @@ and the pyunrealsdk v1.2.0 changelog [here](https://github.com/bl-sdk/pyunrealsd
 
   [c7dfc4a6](https://github.com/bl-sdk/oak-mod-manager/commit/c7dfc4a6)
 
-## v1.2
+## v1.2: Hand of Glory
 
 Also see the pyunrealsdk v1.1.1 changelog [here](https://github.com/bl-sdk/pyunrealsdk/blob/master/changelog.md#v111).
 
@@ -233,8 +233,7 @@ Also see the pyunrealsdk v1.1.1 changelog [here](https://github.com/bl-sdk/pyunr
 
   [05891ad4](https://github.com/bl-sdk/oak-mod-manager/commit/05891ad4)
 
-## v1.1
-
+## v1.1: Rowan's Call
 Also see the unrealsdk v1.1.0 changelog [here](https://github.com/bl-sdk/unrealsdk/blob/master/changelog.md#v110)
 and the pyunrealsdk v1.1.0 changelog [here](https://github.com/bl-sdk/pyunrealsdk/blob/master/changelog.md#v110).
 
@@ -376,5 +375,5 @@ and the pyunrealsdk v1.1.0 changelog [here](https://github.com/bl-sdk/pyunrealsd
 
   [11470d75](https://github.com/bl-sdk/oak-mod-manager/commit/11470d75)
 
-## v1.0
+## v1.0: Major Kong
 - Initial Release

--- a/pick_release_name.py
+++ b/pick_release_name.py
@@ -694,25 +694,28 @@ UNIQUE_ITEM_NAMES = [
     "Zheitsev's Eruption",
 ]
 
-PREVIOUS_RELEASE_NAMES = []
+PREVIOUS_RELEASE_NAMES = [
+    "Major Kong",
+    "Rowan's Call",
+    "Hand of Glory",
+    "Lethal Catch",
+    "White Elephant",
+    "Time Skip",
+]
 
 
 @cache
-def get_git_commit_hash(identifier: str | None = None) -> str:
+def get_git_commit_hash(identifier: str = "HEAD") -> str:
     """
     Gets the full commit hash of the current git repo.
 
     Args:
-        identifier: The identifier of the commit to get, or None to get the latest.
+        identifier: The identifier of the commit to get.
     Returns:
         The commit hash.
     """
-    args = ["git", "show", "-s", "--format=%H"]
-    if identifier is not None:
-        args.append(identifier)
-
     return subprocess.run(
-        args,
+        ["git", "rev-list", "-1", identifier],
         cwd=Path(__file__).parent,
         check=True,
         stdout=subprocess.PIPE,
@@ -744,10 +747,10 @@ if __name__ == "__main__":
         description="Picks the friendly name to use for the current release.",
     )
     parser.add_argument(
-        "hash",
+        "commit",
         nargs="?",
-        default=None,
-        help="The commit hash to base the name off of. If not given, retrieves from git.",
+        default="HEAD",
+        help="The commit hash to base the name off of. Defaults to HEAD.",
     )
     parser.add_argument(
         "--exclude",
@@ -763,7 +766,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    commit_hash = get_git_commit_hash(args.hash)
+    commit_hash = get_git_commit_hash(args.commit)
 
     excludes = [] if args.ignore_previous_releases else PREVIOUS_RELEASE_NAMES
     excludes += args.exclude


### PR DESCRIPTION
by basing it on commits, and rerolling dupes instead of changing the list, we can safely generate the names for previous releases too

switch `get_git_commit_hash` to use `git rev-list` to properly handle tags